### PR TITLE
Wifi users

### DIFF
--- a/autoboot.sh
+++ b/autoboot.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # Options
+HOTSPOT_NM='Hotspot'
 WORKDIR="${PWD}"
 LOG_FILE="$WORKDIR"/conjuring.log
 CUSTOM_DIR='/media/*/*/conjuring/custom'
@@ -25,7 +26,7 @@ log(){
 }
 echo -n '' > $LOG_FILE
 
-log info Starting 'Wi-Fi: "Hotspot"' >> $LOG_FILE 2>&1
+log info Starting $'Wi-Fi: \"'"$HOTSPOT_NM"$'\"' >> $LOG_FILE 2>&1
 nmcli connection up Hotspot >> $LOG_FILE 2>&1
 
 log debug Ensuring sshserver >> $LOG_FILE 2>&1

--- a/autoboot.sh
+++ b/autoboot.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Options
-HOTSPOT_NM='Hotspot'
+HOTSPOT_NM='Conjuring Hotspot'
 WORKDIR="${PWD}"
 LOG_FILE="$WORKDIR"/conjuring.log
 CUSTOM_DIR='/media/*/*/conjuring/custom'
@@ -27,7 +27,7 @@ log(){
 echo -n '' > $LOG_FILE
 
 log info Starting $'Wi-Fi: \"'"$HOTSPOT_NM"$'\"' >> $LOG_FILE 2>&1
-nmcli connection up Hotspot >> $LOG_FILE 2>&1
+nmcli connection up $'\"'"$HOTSPOT_NM"$'\"' >> $LOG_FILE 2>&1
 
 log debug Ensuring sshserver >> $LOG_FILE 2>&1
 sudo service ssh start

--- a/autoboot.sh
+++ b/autoboot.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 # Options
-HOTSPOT_NM='Conjuring Hotspot'
+WIFI_SERVE_NET=Hotspot
+WIFI_BUILD_NET=""  # e.g. eduroam. TODO: special value for auto?
 WORKDIR="${PWD}"
 LOG_FILE="$WORKDIR"/conjuring.log
 CUSTOM_DIR='/media/*/*/conjuring/custom'
@@ -26,11 +27,16 @@ log(){
 }
 echo -n '' > $LOG_FILE
 
-log info Starting $'Wi-Fi: \"'"$HOTSPOT_NM"$'\"' >> $LOG_FILE 2>&1
-nmcli connection up $'\"'"$HOTSPOT_NM"$'\"' >> $LOG_FILE 2>&1
-
 log debug Ensuring sshserver >> $LOG_FILE 2>&1
 sudo service ssh start
+
+netup(){
+  if [ -n "$1" ]; then
+    log info Starting/connecting to network: "'$1'" >> $LOG_FILE 2>&1
+    nmcli connection up "$1" >> $LOG_FILE 2>&1
+  fi
+}
+# netup "$WIFI_BUILD_NET"
 
 # docker container with mounted shared folder(s)
 dcc(){
@@ -40,8 +46,10 @@ dcc(){
   popd
 }
 dccup(){
+  netup "$WIFI_BUILD_NET"
   dcc build --pull base
   dcc up --build -d
+  netup "$WIFI_SERVE_NET"
 }
 
 supports_perms(){

--- a/autoboot.sh
+++ b/autoboot.sh
@@ -1,12 +1,89 @@
 #!/usr/bin/env bash
+show_help(){
+echo 'Usage:
+  '$0' [options] [<workdir>]
 
-# Options
+A script which:
+- starts an ssh server
+- connects to the specified --build-net
+- (re)builds a conjuring docker image based on the given <workdir> configuration
+- starts a conjuring container
+- connects to the specified --serve-net
+- continuously monitors --monitor-dir for additional configuration
+
+Flags:
+  -h, --help
+Options:
+  -s, --serve-net  (default: Hotspot)
+  -b, --build-net  (e.g. eduroam)
+  -l, --log-file  (default: conjuring.log)
+  -m, --monitor-dir  (default: /media/*/*/conjuring/custom)
+Arguments:
+  workdir (default: current)
+'
+}
+
+set -o errexit -o pipefail -o noclobber -o nounset
+OPTIND=1  # reset getopts
+
+# defaults
+## options
 WIFI_SERVE_NET=Hotspot
-WIFI_BUILD_NET=""  # e.g. eduroam. TODO: special value for auto?
-WORKDIR="${PWD}"
-LOG_FILE="$WORKDIR"/conjuring.log
+WIFI_BUILD_NET=""  # TODO: special value for auto?
+LOG_FILE=conjuring.log
 CUSTOM_DIR='/media/*/*/conjuring/custom'
+## arguments
+WORKDIR="${PWD}"
+## internal
 CUSTOM_ROOT_FILES="docker-compose.override.yml"
+
+OPTIONS=hs:b:l:m:
+LONGOPTS=help,serve-net:,build-net:,log-file:,monitor-dir:
+
+! PARSED=$(getopt --options=$OPTIONS --longoptions=$LONGOPTS --name "$0" -- "$@")
+[[ ${PIPESTATUS[0]} -ne 0 ]] && exit 2
+eval set -- "$PARSED"
+
+while true; do
+  case "$1" in
+  -h|--help)
+    show_help
+    exit 0
+    ;;
+  -s|--serve-net)
+    WIFI_SERVE_NET="$2"
+    shift 2
+    ;;
+  -b|--build-net)
+    WIFI_BUILD_NET="$2"
+    shift 2
+    ;;
+  -l|--log-file)
+    LOG_FILE="$2"
+    shift 2
+    ;;
+  -m|--monitor-dir)
+    CUSTOM_DIR="$2"
+    shift 2
+    ;;
+  --)
+    shift
+    break
+    ;;
+  *)
+    echo "Programming error"
+    exit 3
+    ;;
+  esac
+done
+
+shift $((OPTIND-1))
+
+[ "${1:-}" = "--" ] && shift
+
+WORKDIR="${1:-$WORKDIR}"
+
+# end options
 
 log(){
   level=$1
@@ -25,6 +102,7 @@ log(){
     ;;
   esac
 }
+rm -f $LOG_FILE
 echo -n '' > $LOG_FILE
 
 log debug Ensuring sshserver >> $LOG_FILE 2>&1
@@ -48,8 +126,9 @@ dcc(){
 dccup(){
   netup "$WIFI_BUILD_NET"
   dcc build --pull base
-  dcc up --build -d
+  dcc up --build --no-start
   netup "$WIFI_SERVE_NET"
+  dcc up -d
 }
 
 supports_perms(){
@@ -67,6 +146,7 @@ supports_perms(){
 
 usb_monitor(){
   log info Monitor for a USB storage device containing additional config
+  usb_found=""
   while [ true ]; do
     if [ -n "$usb_found" ]; then
       ls $CUSTOM_DIR &>/dev/null || usb_found=''

--- a/autoboot.sh
+++ b/autoboot.sh
@@ -11,6 +11,11 @@ A script which:
 - connects to the specified --serve-net
 - continuously monitors --monitor-dir for additional configuration
 
+Consider adding to system startup using:
+  crontab -e
+and adding the line
+  @reboot cd '$(dirname $0)' && ./autoboot.sh
+
 Flags:
   -h, --help
 Options:

--- a/custom/users.csv
+++ b/custom/users.csv
@@ -1,3 +1,3 @@
-name,password (first row is header)
+name,password,admin (first row is header)
 john,aBadPswd
-jane,0zSndTSHd
+jane,0zSndTSHd,true

--- a/src/create_users.py
+++ b/src/create_users.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+
+import os
+import csv 
+import string
+import secrets
+import random 
+import argparse
+
+custom_dir = 'custom'
+users_file = 'users.csv'
+header = ['Username','Password']
+password_chars = list(string.ascii_letters) + list(string.digits) + ['_',':',';','(',')']
+
+import argparse
+
+parser=argparse.ArgumentParser(
+    description='''
+    This script is designed to make it easy (easier) to create the CSV file
+    of usernames and passwords expected by the Conjuring Dockerfile. We need
+    to do this because JupyterHub expects all users to have entries in PAM
+    (or it's equivalent), so as part of the setup we need to create a 'real'
+    user in the container for JupyterHub to use.
+    ''',
+    epilog="""Please see https://github.com/conjuring/conjuring for more help/to report issues.""")
+parser.add_argument('--num', type=int, default=20, help='The number of users to create (defaults to 20).')
+parser.add_argument('--usernm', type=str, default="conjuring", help="If you want to set up usernames that follow a template that would be familiar to students/participants then specify a string here and the user \'number\' will be appended to this (defaults to conjuring).")
+parser.add_argument('--pwdlen', type=int, default=8, help='The length of passwords to create (defaults to 8 as we\'re not that concerned about security).')
+parser.add_argument('--unsafe_pwd', type=str, default=None, help='If you want to use a password format like \'test1\'..\'testn\' then specify a string template here. Defaults to None on the basis that you _should_ generate random passwords where possible.')
+parser.add_argument('--create_admin', type=bool, default=False, help='Do you want to create an admin user? Defaults to False for basic security reasons.')
+parser.add_argument('--admin_user', type=str, default="admin", help='Name of admin user if not \'admin\' (optional)')
+parser.add_argument('--admin_len', type=int, default=12, help='Length of admin user password (defaults to 12 for security reasons).')
+
+args=parser.parse_args()
+
+print("Generating usernames and passwords for use by Conjuring container and JupyterHub...")
+
+if args.unsafe_pwd is not None:
+    print("\tDefaulting to unsafe passwords based on '{0}' + user number".format(args.unsafe_pwd))
+
+with open(os.path.join('.',custom_dir,users_file), 'w', newline='') as csvfile:
+    pwd = csv.writer(csvfile, delimiter=',',
+                            quotechar='|', quoting=csv.QUOTE_MINIMAL)
+    pwd.writerow(header)
+
+    for i in range(1,args.num+1):
+        if args.unsafe_pwd is not None:
+            pwd.writerow([args.usernm + str(i), args.unsafe_pwd + str(i)])
+        else:
+            pwd.writerow([args.usernm + str(i), ''.join(secrets.choice(password_chars) for i in range(args.pwdlen))])
+    print("\tCreated username and password for " + str(args.num) + " users.")
+
+    if args.create_admin is True:
+        pwd.writerow([args.admin_user, ''.join(secrets.choice(password_chars) for i in range(args.admin_len))])
+        print("\tCreated admin username (" + args.admin_user + ") and password.")
+
+exit()

--- a/src/create_users.py
+++ b/src/create_users.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 # This script is designed to make it easy (easier) to create the CSV file
 # of usernames and passwords expected by the Conjuring Dockerfile. We need

--- a/src/create_users.py
+++ b/src/create_users.py
@@ -1,18 +1,29 @@
 #!/usr/bin/env python
 
+# This script is designed to make it easy (easier) to create the CSV file
+# of usernames and passwords expected by the Conjuring Dockerfile. We need
+# to do this because JupyterHub expects all users to have entries in PAM
+# (or it's equivalent), so as part of the setup we need to create a 'real'
+# user in the container for JupyterHub to use.
+#
+# Please use create_users.py -h to see available options for generating these. 
+# A few parameters are specified within this script since they are unlikely to
+# ever be changed by the user. These can be found just below the import statements.
+
 import os
 import csv 
 import string
 import secrets
-import random 
 import argparse
 
+# Where to find Conjuring's custom directory and, within that, the users file 
+# that will be used to create users in the container.
 custom_dir = 'custom'
 users_file = 'users.csv'
+
+# Some necessary elements of the CSV file and password creation process.
 header = ['Username','Password']
 password_chars = list(string.ascii_letters) + list(string.digits) + ['_',':',';','(',')']
-
-import argparse
 
 parser=argparse.ArgumentParser(
     description='''
@@ -30,26 +41,65 @@ parser.add_argument('--unsafe_pwd', type=str, default=None, help='If you want to
 parser.add_argument('--create_admin', type=bool, default=False, help='Do you want to create an admin user? Defaults to False for basic security reasons.')
 parser.add_argument('--admin_user', type=str, default="admin", help='Name of admin user if not \'admin\' (optional)')
 parser.add_argument('--admin_len', type=int, default=12, help='Length of admin user password (defaults to 12 for security reasons).')
+parser.add_argument('--append', type=bool, default=False, help='If we have already created users but need to add some more then we don\'t want to blow away the existing users.')
 
 args=parser.parse_args()
 
 print("Generating usernames and passwords for use by Conjuring container and JupyterHub...")
 
+# Figure we should reinforce this choice for the user (in case the param name wasn't enough).
 if args.unsafe_pwd is not None:
     print("\tDefaulting to unsafe passwords based on '{0}' + user number".format(args.unsafe_pwd))
 
-with open(os.path.join('.',custom_dir,users_file), 'w', newline='') as csvfile:
+# If we are appending then we need to see where we stopped creating users so that we can 
+# initialise our starting point as the maximum + 1 of the _previous_ list of user numbers.
+start_pt = 1
+write_md = 'w'
+if args.append is True:
+    # Read in the file 
+    with open(os.path.join('.',custom_dir,users_file), 'r') as csvfile:
+        pwd = csv.reader(csvfile, delimiter=',',
+                            quotechar='|')
+        
+        # We're going to try to extract the _last_ username if there's
+        # no admin user, or the _second to last_ username if there is an
+        # admin user. Note that this assumes you're aren't changing the 
+        # settings after running the users script for the first time!
+        try: 
+            last_user = list(pwd)[(-2 if args.create_admin is True else -1)][0] # Ternary operator to switch between -1 and -2 from users list
+            start_pt  = int(last_user.replace(args.usernm,''))+1 # Assume user name template can't change so to just remove the template and take what's left (should be an int)
+            write_md = 'a' # Change the write mode to append
+            args.create_admin = False # Don't re-create the admin user
+        except IndexError:
+            # Suggests that the file exists but is empty/uninitialised, so pass without setting write mode.
+            # You could also get other errors from the above section, but they would suggest that 
+            # user has changed the configuration parameters _after_ initialising the container
+            # which is something we don't want to deal with.
+            pass 
+
+# And write the CSV file
+with open(os.path.join('.',custom_dir,users_file), write_md, newline='') as csvfile:
     pwd = csv.writer(csvfile, delimiter=',',
                             quotechar='|', quoting=csv.QUOTE_MINIMAL)
-    pwd.writerow(header)
+    
+    # Only write header row if _not_ appending.
+    if args.append is False: 
+        pwd.writerow(header)
 
-    for i in range(1,args.num+1):
+    # Create new users from starting point (can be 1 for new file or the last
+    # non-admin user created if appending to file)
+    for i in range(start_pt,start_pt+args.num):
+
+        # Generate password according to specified user policy.
         if args.unsafe_pwd is not None:
             pwd.writerow([args.usernm + str(i), args.unsafe_pwd + str(i)])
         else:
             pwd.writerow([args.usernm + str(i), ''.join(secrets.choice(password_chars) for i in range(args.pwdlen))])
-    print("\tCreated username and password for " + str(args.num) + " users.")
+    print("\tCreated username and password for " + ('' if args.append is False else 'another ') + str(args.num) + " users.")
 
+    # Create admin user. This can be set to False above if script detects that 
+    # file already exists so that user doesn't accidentally re-create the
+    # admin user later.
     if args.create_admin is True:
         pwd.writerow([args.admin_user, ''.join(secrets.choice(password_chars) for i in range(args.admin_len))])
         print("\tCreated admin username (" + args.admin_user + ") and password.")

--- a/src/create_users.py
+++ b/src/create_users.py
@@ -1,50 +1,59 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+"""
+This script is designed to make it easy (easier) to create the CSV file
+of usernames and passwords expected by the Conjuring Dockerfile. We need
+to do this because JupyterHub expects all users to have entries in PAM
+(or its equivalent), so as part of the setup we need to create a 'real'
+user in the container for JupyterHub to use.
 
-# This script is designed to make it easy (easier) to create the CSV file
-# of usernames and passwords expected by the Conjuring Dockerfile. We need
-# to do this because JupyterHub expects all users to have entries in PAM
-# (or it's equivalent), so as part of the setup we need to create a 'real'
-# user in the container for JupyterHub to use.
-#
-# Please use create_users.py -h to see available options for generating these. 
-# A few parameters are specified within this script since they are unlikely to
-# ever be changed by the user. These can be found just below the import statements.
+Usage:
+  create_users.py [options]
 
+Options:
+  -h, --help        Show this help message and exit.
+  --num NUM         The number of users to create [default: 20:int].
+  --usernm USERNM   If you want to set up usernames that follow a template
+                    that would be familiar to students/participants then
+                    specify a string here and the user 'number' will be
+                    appended to this [default: conjuring].
+  --pwdlen PWDLEN   The length of passwords to create ([default: 8:int] as
+                    we're not that concerned about security.
+  --unsafe_pwd UNSAFE_PWD
+        If you want to use a password format like
+        'test1'..'testn' then specify a string template here.
+        Defaults to None on the basis that you _should_
+        generate random passwords where possible.
+  --create_admin    Do you want to create an admin user? (default: False
+                    for basic security reasons.)
+  --admin_user ADMIN_USER  Name of admin user [default: admin]
+  --admin_len ADMIN_LEN     Length of admin user password ([default: 12:int]
+                            for security reasons).
+  --append  If we have already created users but need to add some
+            more then we don't want to blow away the existing users.
+
+A few parameters are specified within this script since they are unlikely to
+ever be changed by the user.
+These can be found just below the import statements.
+
+Please see https://github.com/conjuring/conjuring for more help/to report
+issues.
+"""
 import os
-import csv 
+import csv
 import string
 import secrets
-import argparse
+from argopt import argopt
 
-# Where to find Conjuring's custom directory and, within that, the users file 
+# Where to find Conjuring's users file
 # that will be used to create users in the container.
-custom_dir = 'custom'
-users_file = 'users.csv'
+users_file = os.path.join('.', 'custom', 'users1.csv')
 
 # Some necessary elements of the CSV file and password creation process.
 header = ['Username','Password']
 password_chars = list(string.ascii_letters) + list(string.digits) + ['_',':',';','(',')']
 
-parser=argparse.ArgumentParser(
-    description='''
-    This script is designed to make it easy (easier) to create the CSV file
-    of usernames and passwords expected by the Conjuring Dockerfile. We need
-    to do this because JupyterHub expects all users to have entries in PAM
-    (or it's equivalent), so as part of the setup we need to create a 'real'
-    user in the container for JupyterHub to use.
-    ''',
-    epilog="""Please see https://github.com/conjuring/conjuring for more help/to report issues.""")
-parser.add_argument('--num', type=int, default=20, help='The number of users to create (defaults to 20).')
-parser.add_argument('--usernm', type=str, default="conjuring", help="If you want to set up usernames that follow a template that would be familiar to students/participants then specify a string here and the user \'number\' will be appended to this (defaults to conjuring).")
-parser.add_argument('--pwdlen', type=int, default=8, help='The length of passwords to create (defaults to 8 as we\'re not that concerned about security).')
-parser.add_argument('--unsafe_pwd', type=str, default=None, help='If you want to use a password format like \'test1\'..\'testn\' then specify a string template here. Defaults to None on the basis that you _should_ generate random passwords where possible.')
-parser.add_argument('--create_admin', type=bool, default=False, help='Do you want to create an admin user? Defaults to False for basic security reasons.')
-parser.add_argument('--admin_user', type=str, default="admin", help='Name of admin user if not \'admin\' (optional)')
-parser.add_argument('--admin_len', type=int, default=12, help='Length of admin user password (defaults to 12 for security reasons).')
-parser.add_argument('--append', type=bool, default=False, help='If we have already created users but need to add some more then we don\'t want to blow away the existing users.')
-
-args=parser.parse_args()
+args = argopt(__doc__).parse_args()
 
 print("Generating usernames and passwords for use by Conjuring container and JupyterHub...")
 
@@ -52,39 +61,38 @@ print("Generating usernames and passwords for use by Conjuring container and Jup
 if args.unsafe_pwd is not None:
     print("\tDefaulting to unsafe passwords based on '{0}' + user number".format(args.unsafe_pwd))
 
-# If we are appending then we need to see where we stopped creating users so that we can 
+# If we are appending then we need to see where we stopped creating users so that we can
 # initialise our starting point as the maximum + 1 of the _previous_ list of user numbers.
 start_pt = 1
 write_md = 'w'
 if args.append is True:
-    # Read in the file 
-    with open(os.path.join('.',custom_dir,users_file), 'r') as csvfile:
-        pwd = csv.reader(csvfile, delimiter=',',
-                            quotechar='|')
-        
+    # Read in the file
+    with open(users_file, 'r') as csvfile:
+        pwd = csv.reader(csvfile, delimiter=',', quotechar='"')
+
         # We're going to try to extract the _last_ username if there's
         # no admin user, or the _second to last_ username if there is an
-        # admin user. Note that this assumes you're aren't changing the 
+        # admin user. Note that this assumes you're aren't changing the
         # settings after running the users script for the first time!
-        try: 
+        try:
             last_user = list(pwd)[(-2 if args.create_admin is True else -1)][0] # Ternary operator to switch between -1 and -2 from users list
             start_pt  = int(last_user.replace(args.usernm,''))+1 # Assume user name template can't change so to just remove the template and take what's left (should be an int)
             write_md = 'a' # Change the write mode to append
             args.create_admin = False # Don't re-create the admin user
         except IndexError:
             # Suggests that the file exists but is empty/uninitialised, so pass without setting write mode.
-            # You could also get other errors from the above section, but they would suggest that 
+            # You could also get other errors from the above section, but they would suggest that
             # user has changed the configuration parameters _after_ initialising the container
             # which is something we don't want to deal with.
-            pass 
+            pass
 
 # And write the CSV file
-with open(os.path.join('.',custom_dir,users_file), write_md, newline='') as csvfile:
+with open(users_file, write_md, newline='') as csvfile:
     pwd = csv.writer(csvfile, delimiter=',',
                             quotechar='|', quoting=csv.QUOTE_MINIMAL)
-    
+
     # Only write header row if _not_ appending.
-    if args.append is False: 
+    if args.append is False:
         pwd.writerow(header)
 
     # Create new users from starting point (can be 1 for new file or the last
@@ -98,7 +106,7 @@ with open(os.path.join('.',custom_dir,users_file), write_md, newline='') as csvf
             pwd.writerow([args.usernm + str(i), ''.join(secrets.choice(password_chars) for i in range(args.pwdlen))])
     print("\tCreated username and password for " + ('' if args.append is False else 'another ') + str(args.num) + " users.")
 
-    # Create admin user. This can be set to False above if script detects that 
+    # Create admin user. This can be set to False above if script detects that
     # file already exists so that user doesn't accidentally re-create the
     # admin user later.
     if args.create_admin is True:

--- a/src/create_users.py
+++ b/src/create_users.py
@@ -47,38 +47,50 @@ from argopt import argopt
 
 # Where to find Conjuring's users file
 # that will be used to create users in the container.
-users_file = os.path.join('.', 'custom', 'users1.csv')
+users_file = os.path.join(".", "custom", "users1.csv")
 
 # Some necessary elements of the CSV file and password creation process.
-header = ['Username','Password']
-password_chars = list(string.ascii_letters) + list(string.digits) + ['_',':',';','(',')']
+header = ["Username", "Password"]
+password_chars = (
+    list(string.ascii_letters) + list(string.digits) + ["_", ":", ";", "(", ")"]
+)
 
 args = argopt(__doc__).parse_args()
 
-print("Generating usernames and passwords for use by Conjuring container and JupyterHub...")
+print(
+    "Generating usernames and passwords for use by Conjuring container and JupyterHub..."
+)
 
 # Figure we should reinforce this choice for the user (in case the param name wasn't enough).
 if args.unsafe_pwd is not None:
-    print("\tDefaulting to unsafe passwords based on '{0}' + user number".format(args.unsafe_pwd))
+    print(
+        "\tDefaulting to unsafe passwords based on '{0}' + user number".format(
+            args.unsafe_pwd
+        )
+    )
 
 # If we are appending then we need to see where we stopped creating users so that we can
 # initialise our starting point as the maximum + 1 of the _previous_ list of user numbers.
 start_pt = 1
-write_md = 'w'
+write_md = "w"
 if args.append is True:
     # Read in the file
-    with open(users_file, 'r') as csvfile:
-        pwd = csv.reader(csvfile, delimiter=',', quotechar='"')
+    with open(users_file, "r") as csvfile:
+        pwd = csv.reader(csvfile, delimiter=",", quotechar='"')
 
         # We're going to try to extract the _last_ username if there's
         # no admin user, or the _second to last_ username if there is an
         # admin user. Note that this assumes you're aren't changing the
         # settings after running the users script for the first time!
         try:
-            last_user = list(pwd)[(-2 if args.create_admin is True else -1)][0] # Ternary operator to switch between -1 and -2 from users list
-            start_pt  = int(last_user.replace(args.usernm,''))+1 # Assume user name template can't change so to just remove the template and take what's left (should be an int)
-            write_md = 'a' # Change the write mode to append
-            args.create_admin = False # Don't re-create the admin user
+            last_user = list(pwd)[(-2 if args.create_admin is True else -1)][
+                0
+            ]  # Ternary operator to switch between -1 and -2 from users list
+            start_pt = (
+                int(last_user.replace(args.usernm, "")) + 1
+            )  # Assume user name template can't change so to just remove the template and take what's left (should be an int)
+            write_md = "a"  # Change the write mode to append
+            args.create_admin = False  # Don't re-create the admin user
         except IndexError:
             # Suggests that the file exists but is empty/uninitialised, so pass without setting write mode.
             # You could also get other errors from the above section, but they would suggest that
@@ -87,9 +99,8 @@ if args.append is True:
             pass
 
 # And write the CSV file
-with open(users_file, write_md, newline='') as csvfile:
-    pwd = csv.writer(csvfile, delimiter=',',
-                            quotechar='|', quoting=csv.QUOTE_MINIMAL)
+with open(users_file, write_md, newline="") as csvfile:
+    pwd = csv.writer(csvfile, delimiter=",", quotechar="|", quoting=csv.QUOTE_MINIMAL)
 
     # Only write header row if _not_ appending.
     if args.append is False:
@@ -97,20 +108,35 @@ with open(users_file, write_md, newline='') as csvfile:
 
     # Create new users from starting point (can be 1 for new file or the last
     # non-admin user created if appending to file)
-    for i in range(start_pt,start_pt+args.num):
+    for i in range(start_pt, start_pt + args.num):
 
         # Generate password according to specified user policy.
         if args.unsafe_pwd is not None:
             pwd.writerow([args.usernm + str(i), args.unsafe_pwd + str(i)])
         else:
-            pwd.writerow([args.usernm + str(i), ''.join(secrets.choice(password_chars) for i in range(args.pwdlen))])
-    print("\tCreated username and password for " + ('' if args.append is False else 'another ') + str(args.num) + " users.")
+            pwd.writerow(
+                [
+                    args.usernm + str(i),
+                    "".join(secrets.choice(password_chars) for i in range(args.pwdlen)),
+                ]
+            )
+    print(
+        "\tCreated username and password for "
+        + ("" if args.append is False else "another ")
+        + str(args.num)
+        + " users."
+    )
 
     # Create admin user. This can be set to False above if script detects that
     # file already exists so that user doesn't accidentally re-create the
     # admin user later.
     if args.create_admin is True:
-        pwd.writerow([args.admin_user, ''.join(secrets.choice(password_chars) for i in range(args.admin_len))])
+        pwd.writerow(
+            [
+                args.admin_user,
+                "".join(secrets.choice(password_chars) for i in range(args.admin_len)),
+            ]
+        )
         print("\tCreated admin username (" + args.admin_user + ") and password.")
 
 exit()

--- a/src/create_users.py
+++ b/src/create_users.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-"""
+"""Conjuring user.csv creation helper.
+
 This script is designed to make it easy (easier) to create the CSV file
 of usernames and passwords expected by the Conjuring Dockerfile. We need
 to do this because JupyterHub expects all users to have entries in PAM
@@ -73,7 +74,7 @@ if args.unsafe_pwd is not None:
 # initialise our starting point as the maximum + 1 of the _previous_ list of user numbers.
 start_pt = 1
 write_md = "w"
-if args.append is True:
+if args.append:
     # Read in the file
     with open(users_file, "r") as csvfile:
         pwd = csv.reader(csvfile, delimiter=",", quotechar='"')
@@ -83,7 +84,7 @@ if args.append is True:
         # admin user. Note that this assumes you're aren't changing the
         # settings after running the users script for the first time!
         try:
-            last_user = list(pwd)[(-2 if args.create_admin is True else -1)][
+            last_user = list(pwd)[(-2 if args.create_admin else -1)][
                 0
             ]  # Ternary operator to switch between -1 and -2 from users list
             start_pt = (
@@ -100,7 +101,9 @@ if args.append is True:
 
 # And write the CSV file
 with open(users_file, write_md, newline="") as csvfile:
-    pwd = csv.writer(csvfile, delimiter=",", quotechar="|", quoting=csv.QUOTE_MINIMAL)
+    pwd = csv.writer(
+        csvfile, delimiter=",", quotechar="|", quoting=csv.QUOTE_MINIMAL
+    )
 
     # Only write header row if _not_ appending.
     if args.append is False:
@@ -117,7 +120,10 @@ with open(users_file, write_md, newline="") as csvfile:
             pwd.writerow(
                 [
                     args.usernm + str(i),
-                    "".join(secrets.choice(password_chars) for i in range(args.pwdlen)),
+                    "".join(
+                        secrets.choice(password_chars)
+                        for i in range(args.pwdlen)
+                    ),
                 ]
             )
     print(
@@ -130,13 +136,18 @@ with open(users_file, write_md, newline="") as csvfile:
     # Create admin user. This can be set to False above if script detects that
     # file already exists so that user doesn't accidentally re-create the
     # admin user later.
-    if args.create_admin is True:
+    if args.create_admin:
         pwd.writerow(
             [
                 args.admin_user,
-                "".join(secrets.choice(password_chars) for i in range(args.admin_len)),
+                "".join(
+                    secrets.choice(password_chars)
+                    for i in range(args.admin_len)
+                ),
             ]
         )
-        print("\tCreated admin username (" + args.admin_user + ") and password.")
+        print(
+            "\tCreated admin username (" + args.admin_user + ") and password."
+        )
 
 exit()

--- a/src/csv2useradd.sh
+++ b/src/csv2useradd.sh
@@ -4,10 +4,24 @@ if [ ${#} -ne 2 ]; then
   exit 1
 fi
 
+ADMINS=""
+
 # first row is heading
-awk -F, 'NR>1{print $1" "$2}' "$1" | while read user pass; do
+awk -F, 'NR>1{print $1" "$2" "$3}' "$1" | while read user pass admin; do
   useradd -g conjuring -m -K UID_MIN=2000 -k "$2" -p $(echo "$pass" | openssl passwd -1 -stdin) "$user"
+  case "$admin" in
+  [1YyTt]|[Yy][Ee][Ss]|[Tt][Rr][Uu][Ee])
+    echo TODO: useradd -G sudoers "$user"
+    ADMINS="${ADMINS:+${ADMINS}, }'$user'"
+    # TODO (minor): remove (subshell-induced duplication)
+    echo "c.Authenticator.admin_users = {$ADMINS}" >> jupyterhub_config.py
+    ;;
+  esac
   pushd /home/"$user"
     [ -e shared ] || ln -s /shared
   popd
 done
+
+if [ -n "$ADMINS" ]; then
+  echo "c.Authenticator.admin_users = {$ADMINS}" >> jupyterhub_config.py
+fi


### PR DESCRIPTION
Have tried to parameterise hotspot name (allowing for hotspot names with spaces) and to create a useful script (with sensible defaults) for creating a specified number of users as well as an admin user who can be promoted in JupyterHub... we assume, however, that the users.csv file is _not_ copied to anywhere that students/end-users can see it.