### PR TITLE
Should prevent CR/LF issues on Windows.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto
+*.sh text eol=lf
+*.py text eol=lf


### PR DESCRIPTION
This _should_ ensure that Python and Bash files don't pick up Windows' carriage return/line feed issues when doing git checkouts and commits.