### PR TITLE
single binary install script

### DIFF
--- a/src/conjuring.sh
+++ b/src/conjuring.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+help='
+Conjuring install helper. Steps to use:
+
+- install `git`
+  + `sudo apt-get install git curl` (linux)
+  + `brew install git curl` (mac)
+  + https://git-scm.com/download (win, includes `git-bash` and `curl` etc.)
+- (win) open `git-bash` terminal
+- `curl -o conjuring https://raw.githubusercontent.com/conjuring/conjuring/master/src/conjuring.sh`
+  + or e.g. `curl -o ~/.local/bin/conjuring https://conjuring.github.io/conjuring.sh`
+- `./conjuring`
+'
+set -e
+
+CWD="${PWD}"
+echo "Ensuring conjuring is up-to-date in ~/.conjuring"
+[ -d ~/.conjuring ] || git clone https://github.com/conjuring/conjuring ~/.conjuring
+pushd ~/.conjuring
+git reset --hard
+git pull
+files="$(ls -xd */ *.yml Dockerfile)"  # slim
+#files=""  # full (incl README.md, Makefile, autoboot.sh, etc)
+echo "Installing conjuring ($files) in $CWD"
+echo -n "Overwrite all, overwrite older, keep existing, or quit [a/o/E/q]? "
+read overwrite
+case "$overwrite" in
+  [aA])
+    git archive --format=tar HEAD $files | (cd "$CWD" && tar -x -f - )
+    ;;
+  [oO])
+    git archive --format=tar HEAD $files | (cd "$CWD" && tar -x -f - --keep-newer-files)
+    ;;
+  [eE]|"")
+    git archive --format=tar HEAD $files | (cd "$CWD" && tar -x -f - --skip-old-files)
+    ;;
+  [qQ])
+    exit 0
+    ;;
+  *)
+    echo "Unknown option; aborting"
+    exit 1
+    ;;
+esac
+popd
+
+docker-compose up --build -d

--- a/src/conjuring.sh
+++ b/src/conjuring.sh
@@ -6,6 +6,7 @@ Conjuring install helper.
 Available commands:
 - $0 up
 - $0 config
+- $0 uninstall
 
 Steps to use:
 - install \`git\`
@@ -64,6 +65,9 @@ docker-compose up --build -d
 case "$1" in
   up|"")
     up "${@:2}"
+    ;;
+  uninstall)
+    rm -rf ~/.conjuring
     ;;
   config)
     config "${@:2}"

--- a/src/conjuring.sh
+++ b/src/conjuring.sh
@@ -1,19 +1,33 @@
 #!/usr/bin/env bash
-help='
-Conjuring install helper. Steps to use:
+help(){
+cat << EOF
+Conjuring install helper.
 
-- install `git`
-  + `sudo apt-get install git curl` (linux)
-  + `brew install git curl` (mac)
-  + https://git-scm.com/download (win, includes `git-bash` and `curl` etc.)
-- (win) open `git-bash` terminal
-- `curl -o conjuring https://raw.githubusercontent.com/conjuring/conjuring/master/src/conjuring.sh`
-  + or e.g. `curl -o ~/.local/bin/conjuring https://conjuring.github.io/conjuring.sh`
-- `./conjuring`
-'
+Available commands:
+- $0 up
+- $0 config
+
+Steps to use:
+- install \`git\`
+  + \`sudo apt-get install git curl\` (linux)
+  + \`brew install git curl\` (mac)
+  + https://git-scm.com/download (win, includes \`git-bash\` and \`curl\` etc.)
+- (win) open \`git-bash\` terminal
+- \`curl -o conjuring https://raw.githubusercontent.com/conjuring/conjuring/master/src/conjuring.sh\`
+  + or e.g. \`curl -o ~/.local/bin/conjuring https://conjuring.github.io/conjuring.sh\`
+- \`./conjuring\`
+EOF
+}
 set -e
 
 CWD="${PWD}"
+
+config(){
+# TODO: prevent irrelevant git-confog optiona
+git config --file conjuring.ini "$@"
+}
+
+up(){
 echo "Ensuring conjuring is up-to-date in ~/.conjuring"
 [ -d ~/.conjuring ] || git clone https://github.com/conjuring/conjuring ~/.conjuring
 pushd ~/.conjuring
@@ -45,3 +59,16 @@ esac
 popd
 
 docker-compose up --build -d
+}
+
+case "$1" in
+  up|"")
+    up "${@:2}"
+    ;;
+  config)
+    config "${@:2}"
+    ;;
+  *)
+    help >&2
+    ;;
+esac

--- a/src/conjuring.sh
+++ b/src/conjuring.sh
@@ -4,8 +4,9 @@ cat << EOF
 Conjuring install helper.
 
 Available commands:
-- $0 up
+- $0 up  # will also `install`
 - $0 config
+- $0 install
 - $0 uninstall
 
 Steps to use:
@@ -24,11 +25,11 @@ set -e
 CWD="${PWD}"
 
 config(){
-# TODO: prevent irrelevant git-confog optiona
+# TODO: prevent irrelevant git-config options
 git config --file conjuring.ini "$@"
 }
 
-up(){
+install_system(){
 echo "Ensuring conjuring is up-to-date in ~/.conjuring"
 [ -d ~/.conjuring ] || git clone https://github.com/conjuring/conjuring ~/.conjuring
 pushd ~/.conjuring
@@ -58,13 +59,19 @@ case "$overwrite" in
     ;;
 esac
 popd
+}
 
+up(){
+install_system
 docker-compose up --build -d
 }
 
 case "$1" in
   up|"")
     up "${@:2}"
+    ;;
+  install)
+    install_system
     ;;
   uninstall)
     rm -rf ~/.conjuring


### PR DESCRIPTION
Conjuring install helper; fixes #20.

- [x] `conjure up` (default, will also "install")
- [x] `conjure config`
- [x] `conjure uninstall`
- [ ] `conjure new/project`
- [ ] `conjure usergen`

Steps to use (once merged):

- install `git`
  + `sudo apt-get install git curl` (linux)
  + `brew install git curl` (mac)
  + https://git-scm.com/download (win, includes `git-bash` and `curl` etc.)
- (win) open `git-bash` terminal
- `curl -o conjuring https://raw.githubusercontent.com/conjuring/conjuring/master/src/conjuring.sh`
  + or e.g. `curl -o ~/.local/bin/conjuring https://conjuring.github.io/conjuring.sh`
- `./conjuring`

If we're happy with the above, I think it's best to address most of the configuration generation options (below) in a separate PR.

- [ ] `conjure` or `conjuring`? (I prefer latter for consistency with this repo's name)
- [ ] `conjure project <name>` / `conjure new <project>`
- [ ] `conjure users`
- [ ] helpful messages "Hey, docker isn't installed so you might want to fix that before running me..."
- [ ] convert current config python scripts to shell scipts for use in this binary
- [ ] running `conjure` new <project> command within another project (e.g. a git repo)
  + [ ] automating copy into custom/shared and custom/home_default?
  + [ ] providing config options for how/what to copy
- [ ] auto-tag images based on project name or folder name
  + @szschaler it's not nice to rely on docker-compose to auto-tag images based on folder names because that may increase the chance of cache misses each rebuild, but maybe we don't care too much about this
  + [ ] maybe remove `container_name`, `image`, and `cache_from` from `services.conjuring` in `docker-compose.yml` to facilitate this