### PR TITLE
Org

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM casperdcl/conjuring:base as core
+FROM conjuring/conjuring:base as core
 LABEL com.jupyter.source="https://hub.docker.com/r/jupyterhub/jupyterhub/dockerfile"
 # modified version of above on this date
 LABEL com.jupyter.date="2019-07-01"

--- a/README.md
+++ b/README.md
@@ -112,17 +112,17 @@ exits, `docker-compose.override.yml`) in order to make the following happen:
 1. `docker` downloads the latest version of the `ubuntu:18.04` *image*
 2. `docker` follows the instructions in
    [custom/base.Dockerfile](custom/base.Dockerfile) to (re)build
-   an *image* called `casperdcl/conjuring:base` (based on `ubuntu:18.04`)
+   an *image* called `conjuring/conjuring:base` (based on `ubuntu:18.04`)
 3. `docker` follows the instructions in the first half of
    [Dockerfile](Dockerfile) to (re)build an *image* called
-   `casperdcl/conjuring:core` (based on `casperdcl/conjuring:base`)
+   `conjuring/conjuring:core` (based on `conjuring/conjuring:base`)
 4. `docker` follows the instructions in the second half of
    [Dockerfile](Dockerfile) to (re)build an *image* called
-   `casperdcl/conjuring:latest` (based on `casperdcl/conjuring:core`)
+   `conjuring/conjuring:latest` (based on `conjuring/conjuring:core`)
     - this references files from the [src/](src/) and [custom/](custom/)
       directories to create users and Jupyter environments
 5. `docker` creates a *container* called `conjuring`
-   (based on `casperdcl/conjuring:latest`) which also does the following:
+   (based on `conjuring/conjuring:latest`) which also does the following:
     - links [custom/home/](custom/home/) to `conjuring:/home/`
     - links [custom/home_default/](custom/home_default) (read-only)
     - populates the container user home directories (`conjuring:/home/*`)
@@ -146,7 +146,7 @@ Run `docker system prune` to clear unused cache.
       (e.g. `apt-get install git`)
 - *Image*: a sequence of *layers* (applied on top of a *base image*)
     + analogous to a clean OS with things set up as specified in `custom/`
-      (in this case *tagged* `casperdcl/conjuring:latest`)
+      (in this case *tagged* `conjuring/conjuring:latest`)
 - *Container*: a sandboxed workspace derived from an *image*
     + analogous to a running virtual machine (in this case named `conjuring`)
     + easily stoppable, restartable, and disposable

--- a/README.md
+++ b/README.md
@@ -181,5 +181,5 @@ editor) which runs in a web browser
 
 - *GitHub*: a website which hosts many *git* repositories
 
-[CI-badge]: https://travis-ci.com/casperdcl/conjuring.svg?token=fZcPAkurhLa1iecqAFAV&branch=master
-[CI]: https://travis-ci.com/casperdcl/conjuring
+[CI-badge]: https://travis-ci.org/conjuring/conjuring.svg?branch=master
+[CI]: https://travis-ci.org/conjuring/conjuring

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,14 +2,14 @@ version: '3.4'
 services:
  conjuring:
   container_name: conjuring
-  image: casperdcl/conjuring:latest
+  image: conjuring/conjuring:latest
   build:
    context: .
    target: conjuring
    cache_from:
-   - casperdcl/conjuring:base
-   - casperdcl/conjuring:core
-   - casperdcl/conjuring:latest
+   - conjuring/conjuring:base
+   - conjuring/conjuring:core
+   - conjuring/conjuring:latest
    args:
     GROUP_ID: ${GROUPS:-1000}
   depends_on:
@@ -26,22 +26,22 @@ services:
   - ./custom/home_default:/opt/home_default:ro
   - ./custom/home:/home
  core:
-  image: casperdcl/conjuring:core
+  image: conjuring/conjuring:core
   build:
    context: .
    target: core
    cache_from:
-   - casperdcl/conjuring:base
-   - casperdcl/conjuring:core
+   - conjuring/conjuring:base
+   - conjuring/conjuring:core
   depends_on:
   - base
   command: ["/bin/bash", "-c", "exit 0"]
  base:
-  image: casperdcl/conjuring:base
+  image: conjuring/conjuring:base
   build:
    context: .
    dockerfile: custom/base.Dockerfile
    target: base
    cache_from:
-   - casperdcl/conjuring:base
+   - conjuring/conjuring:base
   command: ["/bin/bash", "-c", "exit 0"]


### PR DESCRIPTION
complete migration to organisation

- fixes #18

## transfer checklist

- [x] change docker image tags `casperdcl/conjuring` -> `conjuring/conjuring`
- [x] host on https://hub.docker.com/u/conjuring
  + [ ] auto-push from travis CI
- [x] make public
- [x] transfer https://github.com/casperdcl/conjuring -> https://github.com/conjuring/conjuring/ (maybe contacting GitHub to ensure no data loss)
- [x] move project board to org-wide
- [x] create org maintainers team
- [x] integrate zenodo (waiting on https://github.com/zenodo/zenodo/issues/1867)
- [x] update travis CI to point to new repo (and move from .com to .org)